### PR TITLE
Method: apply

### DIFF
--- a/spec/Result/ErrSpec.php
+++ b/spec/Result/ErrSpec.php
@@ -147,4 +147,10 @@ class ErrSpec extends ObjectBehavior
         $option->shouldHaveType(Some::class);
         $option->unwrap()->shouldBe("error");
     }
+
+    function it_does_not_apply_args_in_an_err()
+    {
+        $this->beConstructedWith("error");
+        $this->apply(new Ok(123))->isErr()->shouldBe(true);
+    }
 }

--- a/spec/Result/OkSpec.php
+++ b/spec/Result/OkSpec.php
@@ -162,4 +162,10 @@ class OkSpec extends ObjectBehavior
         });
         $this->apply(new Ok(1), new Ok(2), new Err(3))->isErr()->shouldBe(true);
     }
+
+    function it_throws_if_non_callable_value_is_applied_to_arguments()
+    {
+        $this->beConstructedWith(1);
+        $this->shouldThrow(ResultException::class)->during("apply");
+    }
 }

--- a/spec/Result/OkSpec.php
+++ b/spec/Result/OkSpec.php
@@ -137,4 +137,21 @@ class OkSpec extends ObjectBehavior
 
         $option->shouldHaveType(None::class);
     }
+
+    function it_can_apply_argument_to_function()
+    {
+        $this->beConstructedWith(function($one) {
+            return $one;
+        });
+        $arg = new Ok(13);
+        $this->apply($arg)->unwrap()->shouldBe(13);
+    }
+    
+    function it_can_apply_multiple_arguments_to_function()
+    {
+        $this->beConstructedWith(function($x, $y, $z) {
+            return $x + $y + $z;
+        });
+        $this->apply(new Ok(1), new Ok(2), new Ok(3))->unwrap()->shouldBe(6);
+    }
 }

--- a/spec/Result/OkSpec.php
+++ b/spec/Result/OkSpec.php
@@ -4,7 +4,7 @@ namespace spec\Prewk\Result;
 
 use Exception;
 use Prewk\Option\{Some, None};
-use Prewk\Result\Ok;
+use Prewk\Result\{Ok, Err};
 use PhpSpec\ObjectBehavior;
 use Prewk\Result\ResultException;
 
@@ -153,5 +153,13 @@ class OkSpec extends ObjectBehavior
             return $x + $y + $z;
         });
         $this->apply(new Ok(1), new Ok(2), new Ok(3))->unwrap()->shouldBe(6);
+    }
+
+    function it_returns_err_when_one_of_args_is_err()
+    {
+        $this->beConstructedWith(function($x, $y, $z) {
+            return $x + $y + $z;
+        });
+        $this->apply(new Ok(1), new Ok(2), new Err(3))->isErr()->shouldBe(true);
     }
 }

--- a/src/Result.php
+++ b/src/Result.php
@@ -142,4 +142,11 @@ interface Result
      * @return mixed
      */
     public function unwrapErr();
+
+    /**
+     * Applies values inside the given Results to the function in this Result.
+     *
+     * @return Result
+     */
+    public function apply(): Result;
 }

--- a/src/Result.php
+++ b/src/Result.php
@@ -146,7 +146,8 @@ interface Result
     /**
      * Applies values inside the given Results to the function in this Result.
      *
+     * @param Result[] ...$args Results to apply the function to.
      * @return Result
      */
-    public function apply(): Result;
+    public function apply(Result ...$args): Result;
 }

--- a/src/Result/Err.php
+++ b/src/Result/Err.php
@@ -200,6 +200,16 @@ class Err implements Result
     {
         return $this->err;
     }
+    
+    /**
+     * Applies values inside the given Results to the function in this Result.
+     *
+     * @return Result
+     */
+    public function apply(): Result
+    {
+        return $this;
+    }
 
     /**
      * Converts from Result<T, E> to Option<T>, and discarding the error, if any

--- a/src/Result/Err.php
+++ b/src/Result/Err.php
@@ -204,9 +204,10 @@ class Err implements Result
     /**
      * Applies values inside the given Results to the function in this Result.
      *
+     * @param Result[] ...$args Results to apply the function to.
      * @return Result
      */
-    public function apply(): Result
+    public function apply(Result ...$args): Result
     {
         return $this;
     }

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -197,6 +197,25 @@ class Ok implements Result
     }
 
     /**
+     * Applies values inside the given Results to the function in this Result.
+     *
+     * @return Result
+     */
+    public function apply(): Result
+    {
+        return array_reduce(func_get_args(), function($final, $result) {
+            return $final->andThen(function($array) use ($result) {
+                return $result->map(function($x) use ($array) {
+                    array_push($array, $x);
+                    return $array;
+                });
+            });
+        }, new static([]))->map(function($args) {
+            return call_user_func_array($this->value, $args);
+        });
+    }
+
+    /**
      * Converts from Result<T, E> to Option<T>, and discarding the error, if any
      *
      * @return Option

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -199,21 +199,22 @@ class Ok implements Result
     /**
      * Applies values inside the given Results to the function in this Result.
      *
+     * @param Result[] ...$args Results to apply the function to.
      * @return Result
      */
-    public function apply(...$args): Result
+    public function apply(Result ...$args): Result
     {
         if (!is_callable($this->value)) {
             throw new ResultException("Tried to apply a non-callable to arguments");
         }
-        return array_reduce($args, function($final, $result) {
-            return $final->andThen(function($array) use ($result) {
+        return array_reduce($args, function(Result $final, Result $result) {
+            return $final->andThen(function(array $array) use ($result) {
                 return $result->map(function($x) use ($array) {
                     array_push($array, $x);
                     return $array;
                 });
             });
-        }, new static([]))->map(function($argArray) {
+        }, new static([]))->map(function(array $argArray) {
             return call_user_func_array($this->value, $argArray);
         });
     }

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -201,17 +201,17 @@ class Ok implements Result
      *
      * @return Result
      */
-    public function apply(): Result
+    public function apply(...$args): Result
     {
-        return array_reduce(func_get_args(), function($final, $result) {
+        return array_reduce($args, function($final, $result) {
             return $final->andThen(function($array) use ($result) {
                 return $result->map(function($x) use ($array) {
                     array_push($array, $x);
                     return $array;
                 });
             });
-        }, new static([]))->map(function($args) {
-            return call_user_func_array($this->value, $args);
+        }, new static([]))->map(function($argArray) {
+            return call_user_func_array($this->value, $argArray);
         });
     }
 

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -203,6 +203,9 @@ class Ok implements Result
      */
     public function apply(...$args): Result
     {
+        if (!is_callable($this->value)) {
+            throw new ResultException("Tried to apply a non-callable to arguments");
+        }
         return array_reduce($args, function($final, $result) {
             return $final->andThen(function($array) use ($result) {
                 return $result->map(function($x) use ($array) {


### PR DESCRIPTION
🇸🇪  Swedish Warning 🇸🇪 

**tl;dr**
Gör det möjligt att stoppa in en callable (funktion/metod/whateverLolPhp) i ett `Result` och sedan applicera den på argument som också befinner sig i `Result`. Om något av alla `Result` är ett `Err` så returneras ett `Err`, om alla `Result` är `Ok` så returneras ett `Ok` med resultatet av att applicera funktionen på de givna argumenten.

Du känner säkert igen följande mönster:
1. Gör någonting som returnerar `Result<x, _>`
2. Gör någonting annat som returnerar `Result<y, _>`.
3. Om båda tidigare operationer lyckades gör `något(x, y)`.

Det brukar behöva se ut ungefär såhär:
```php
$result1 = $x->getStuff();
$result2 = $y->getMoreStuff();

$theThing = $result1->andThen(function($stuff) use ($result2, $z) {
    return $result2->andThen(function($moreStuff) use ($stuff, $z) {
        return $z->doTheThing($stuff, $moreStuff);
    });
});
```
Och för varje extra argument man behöver till `$z->doTheThing()` så behöver man lägga till ytterligare en nivå av `andThen` och en nivå av indentering.

Men med `apply` skulle det kunna se ut såhär:


```php
$result1 = $x->getStuff();
$result2 = $y->getMoreStuff();

$doTheThing = function($stuff, $moreStuff) {
    return $z->doTheThing($stuff, $moreStuff);
};

$theThing = ok($doTheThing)->apply($result1, $result2);
```

Eller med hjälp av vad php anser vara en  "callable" så skulle följande vara ekvivalent:
```php
$result1 = $x->getStuff();
$result2 = $y->getMoreStuff();
$theThing = ok([$z, "doTheThing"])->apply($result1, $result2);

// Eller helt enkelt

$theThing = ok([$y, "doTheThing"])
    ->apply($x->getStuff(), $y->getMoreStuff());
```

Det kanske låter konstigt, och implementationen ser lite hårig ut. Men apply är ett väldigt användbart koncept.