### PR TITLE
Support variadic pass-through arguments

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -5,16 +5,17 @@
  * @author Oskar Thornblad
  */
 
-if (!function_exists("ok")) {    
+if (!function_exists("ok")) {
     /**
      * Represent a successful result
      *
      * @codeCoverageIgnore
      * @param mixed $value
+     * @param array ...$pass
      * @return Prewk\Result\Ok
      */
-    function ok($value = null): Prewk\Result\Ok {
-        return new Prewk\Result\Ok($value);
+    function ok($value = null, ...$pass): Prewk\Result\Ok {
+        return new Prewk\Result\Ok($value, ...$pass);
     }
 }
 
@@ -23,10 +24,11 @@ if (!function_exists("err")) {
      * Represent a failed result
      *
      * @codeCoverageIgnore
-     * @param mixed $value
+     * @param $err
+     * @param array ...$pass
      * @return Prewk\Result\Err
      */
-    function err($err): Prewk\Result\Err {
-        return new Prewk\Result\Err($err);
+    function err($err, ...$pass): Prewk\Result\Err {
+        return new Prewk\Result\Err($err, $pass);
     }
 }

--- a/spec/Result/ErrSpec.php
+++ b/spec/Result/ErrSpec.php
@@ -153,4 +153,25 @@ class ErrSpec extends ObjectBehavior
         $this->beConstructedWith("error");
         $this->apply(new Ok(123))->isErr()->shouldBe(true);
     }
+
+    function it_mapErrs_with_pass_args()
+    {
+        $this->beConstructedWith("foo", "bar", "baz");
+        $result = $this->mapErr(function($foo, $bar, $baz) {
+            return $foo . $bar . $baz;
+        });
+
+        $result->shouldHaveType(Err::class);
+        $result->unwrapErr()->shouldBe("foobarbaz");
+    }
+
+    function it_orElses_with_pass_args()
+    {
+        $this->beConstructedWith("foo", "bar", "baz");
+        $result = $this->orElse(function($foo, $bar, $baz) {
+            return new Err($foo . $bar . $baz);
+        });
+
+        $result->unwrapErr()->shouldBe("foobarbaz");
+    }
 }

--- a/spec/Result/ErrSpec.php
+++ b/spec/Result/ErrSpec.php
@@ -174,4 +174,16 @@ class ErrSpec extends ObjectBehavior
 
         $result->unwrapErr()->shouldBe("foobarbaz");
     }
+
+    function its_with_method_adds_args()
+    {
+        $this->beConstructedWith("foo");
+        $this->with("bar", "baz");
+
+        $result = $this->orElse(function($foo, $bar, $baz) {
+            return new Err($foo . $bar . $baz);
+        });
+
+        $result->unwrapErr()->shouldBe("foobarbaz");
+    }
 }

--- a/spec/Result/OkSpec.php
+++ b/spec/Result/OkSpec.php
@@ -189,4 +189,16 @@ class OkSpec extends ObjectBehavior
 
         $result->unwrap()->shouldBe("foobarbaz");
     }
+
+    function its_with_method_adds_args()
+    {
+        $this->beConstructedWith("foo");
+        $this->with("bar", "baz");
+
+        $result = $this->andThen(function($foo, $bar, $baz) {
+            return new Ok($foo . $bar . $baz);
+        });
+
+        $result->unwrap()->shouldBe("foobarbaz");
+    }
 }

--- a/spec/Result/OkSpec.php
+++ b/spec/Result/OkSpec.php
@@ -168,4 +168,25 @@ class OkSpec extends ObjectBehavior
         $this->beConstructedWith(1);
         $this->shouldThrow(ResultException::class)->during("apply");
     }
+
+    function it_maps_with_pass_args()
+    {
+        $this->beConstructedWith("foo", "bar", "baz");
+        $result = $this->map(function($foo, $bar, $baz) {
+            return $foo . $bar . $baz;
+        });
+
+        $result->shouldHaveType(Ok::class);
+        $result->unwrap()->shouldBe("foobarbaz");
+    }
+
+    function it_andThens_with_pass_args()
+    {
+        $this->beConstructedWith("foo", "bar", "baz");
+        $result = $this->andThen(function($foo, $bar, $baz) {
+            return new Ok($foo . $bar . $baz);
+        });
+
+        $result->unwrap()->shouldBe("foobarbaz");
+    }
 }

--- a/src/Result.php
+++ b/src/Result.php
@@ -150,4 +150,12 @@ interface Result
      * @return Result
      */
     public function apply(Result ...$args): Result;
+
+    /**
+     * The attached pass-through args will be unpacked into extra args into chained closures
+     *
+     * @param array ...$args
+     * @return Result
+     */
+    public function with(...$args): Result;
 }

--- a/src/Result/Err.php
+++ b/src/Result/Err.php
@@ -238,4 +238,17 @@ class Err implements Result
     {
         return new Some($this->err);
     }
+
+    /**
+     * The attached pass-through args will be unpacked into extra args into chained closures
+     *
+     * @param array ...$args
+     * @return Result
+     */
+    public function with(...$args): Result
+    {
+        $this->pass = $args;
+
+        return $this;
+    }
 }

--- a/src/Result/Err.php
+++ b/src/Result/Err.php
@@ -27,13 +27,20 @@ class Err implements Result
     private $err;
 
     /**
+     * @var array
+     */
+    private $pass;
+
+    /**
      * Err constructor.
      *
      * @param mixed $err
+     * @param array ...$pass
      */
-    public function __construct($err)
+    public function __construct($err, ...$pass)
     {
         $this->err = $err;
+        $this->pass = $pass;
     }
 
     /**
@@ -75,7 +82,7 @@ class Err implements Result
      */
     public function mapErr(Closure $mapper): Result
     {
-        return new self($mapper($this->err));
+        return new self($mapper($this->err, ...$this->pass));
     }
 
     /**
@@ -131,7 +138,7 @@ class Err implements Result
      */
     public function orElse(Closure $op): Result
     {
-        $result = $op($this->err);
+        $result = $op($this->err, ...$this->pass);
 
         if (!($result instanceof Result)) {
             throw new ResultException("Op must return a Result");
@@ -159,7 +166,7 @@ class Err implements Result
      */
     public function unwrapOrElse(Closure $op)
     {
-        return $op($this->err);
+        return $op($this->err, ...$this->pass);
     }
 
     /**

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -245,4 +245,17 @@ class Ok implements Result
     {
         return new None;
     }
+
+    /**
+     * The attached pass-through args will be unpacked into extra args into chained closures
+     *
+     * @param array ...$args
+     * @return Result
+     */
+    public function with(...$args): Result
+    {
+        $this->pass = $args;
+
+        return $this;
+    }
 }

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -27,13 +27,20 @@ class Ok implements Result
     private $value;
 
     /**
+     * @var array
+     */
+    private $pass;
+
+    /**
      * Ok constructor.
      *
      * @param mixed $value
+     * @param array ...$pass
      */
-    public function __construct($value)
+    public function __construct($value, ...$pass)
     {
         $this->value = $value;
+        $this->pass = $pass;
     }
 
     /**
@@ -64,7 +71,7 @@ class Ok implements Result
      */
     public function map(Closure $mapper): Result
     {
-        return new self($mapper($this->value));
+        return new self($mapper($this->value, ...$this->pass));
     }
 
     /**
@@ -109,7 +116,7 @@ class Ok implements Result
      */
     public function andThen(Closure $op): Result
     {
-        $result = $op($this->value);
+        $result = $op($this->value, ...$this->pass);
 
         if (!($result instanceof Result)) {
             throw new ResultException("Op must return a Result");


### PR DESCRIPTION
# Problem

```php
<?php
function fetchFoo(): Result {
    return ok(new Foo);
};
function fetchBarUsingFoo(Foo $foo): Result {
    return ok(new Bar($foo));
};
function fetchBazUsingFooAndBar(Foo $foo, Bar $bar): Result {
    return ok(new Baz($foo, $bar));
};

ok()
    ->andThen(function() {
        return $this->fetchFoo();
    })
    ->andThen(function(Foo $foo) {
        return $this->fetchBarUsingFoo($foo);
    })
    ->andThen(function(Bar $bar) {
        // $foo = ???
        return $this->fetchBazUsingFooAndBar($foo, $bar);
    });
```

# Current solutions

**Mapping inside the `andThen` to transform the `Bar` into a tuple/struct with both values**

Con: Messy, hard to follow, and lots of boilerplate.

**Storing values as class properties (`$this->foo = $foo`)**

Con: The class gets bloated and it introduces unwanted state.

**Having the function (`fetchBarUsingFoo` in this case) return a tuple/struct including arguments coming in**

Con: It might work if the function actually uses all of the arguments to pass through but when that isn't the case it causes horrible anti-patterns and obvious unwanted cohesion. It's also impossible to typehint PHP tuples/structs.

# Proposal

The method `with(...$args): Result` adds arguments variadically to the result which will be unpacked into arguments for later closures:

```php
<?php
ok()
    ->andThen(function() {
        return $this->fetchFoo();
    })
    ->andThen(function(Foo $foo) {
        return $this->fetchBarUsingFoo($foo)->with($foo);
    })
    ->andThen(function(Bar $bar, Foo $foo) {
        return $this->fetchBazUsingFooAndBar($foo, $bar);
    });
```

Other changes:

```php
<?php
// Result constructors take variadic values as optional arguments
new Ok($value, ...$pass);
new Err($err, ...$pass);

// Same goes for helpers
ok($value = null, ...$pass);
err($err, ...$pass);
```