### PR TITLE
Psalm more type coverage with templates

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -10,9 +10,14 @@ if (!function_exists("ok")) {
      * Represent a successful result
      *
      * @codeCoverageIgnore
+     *
+     * @template T
+     *
      * @param mixed $value
-     * @param array ...$pass
+     * @psalm-param T $value
+     * @param mixed ...$pass
      * @return Prewk\Result\Ok
+     * @psalm-return Prewk\Result\Ok<T,mixed>
      */
     function ok($value = null, ...$pass): Prewk\Result\Ok
     {
@@ -25,9 +30,14 @@ if (!function_exists("err")) {
      * Represent a failed result
      *
      * @codeCoverageIgnore
-     * @param $err
+     *
+     * @template E
+     *
+     * @param mixed $err
+     * @psalm-param E $err
      * @param array ...$pass
      * @return Prewk\Result\Err
+     * @psalm-return Prewk\Result\Err<mixed,E>
      */
     function err($err, ...$pass): Prewk\Result\Err
     {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
+        totallyTyped="false"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://getpsalm.org/schema/config"
+        xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 >
     <projectFiles>
         <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
     </projectFiles>
 
     <issueHandlers>

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,6 +7,7 @@
 >
     <projectFiles>
         <directory name="src" />
+        <file name="helpers.php"/>
         <ignoreFiles>
             <directory name="vendor" />
         </ignoreFiles>

--- a/src/Result.php
+++ b/src/Result.php
@@ -70,6 +70,8 @@ abstract class Result
     /**
      * Maps a Result by applying a function to a contained Err value, leaving an Ok value untouched.
      *
+     * @template F
+     *
      * @param Closure $mapper
      * @psalm-param Closure(E=,mixed...):F $mapper
      * @return Result

--- a/src/Result.php
+++ b/src/Result.php
@@ -190,6 +190,7 @@ abstract class Result
      *
      * @param Result ...$inArgs Results to apply the function to.
      * @return Result
+     * @psalm-return Result<mixed,E>
      */
     abstract public function apply(Result ...$inArgs): Result;
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -59,6 +59,7 @@ abstract class Result
      * Maps a Result by applying a function to a contained Ok value, leaving an Err value untouched.
      *
      * @param Closure $mapper
+     * @psalm-param Closure(T):T $mapper
      * @return Result
      */
     abstract public function map(Closure $mapper): Result;
@@ -67,6 +68,7 @@ abstract class Result
      * Maps a Result by applying a function to a contained Err value, leaving an Ok value untouched.
      *
      * @param Closure $mapper
+     * @psalm-param Closure(E):E $mapper
      * @return Result
      */
     abstract public function mapErr(Closure $mapper): Result;
@@ -76,7 +78,7 @@ abstract class Result
      * The iterator yields one value if the result is Ok, otherwise none.
      *
      * @return array
-     * @psalm-return array<int, mixed>
+     * @psalm-return array<int, T>
      */
     abstract public function iter(): array;
 
@@ -125,6 +127,7 @@ abstract class Result
      * Unwraps a result, yielding the content of an Ok. If the value is an Err then it calls op with its value.
      *
      * @param Closure $op
+     * @psalm-param Closure(E) $op
      * @return mixed
      * @psalm-return T|mixed
      */
@@ -133,28 +136,28 @@ abstract class Result
     /**
      * Unwraps a result, yielding the content of an Ok.
      *
-     * @throws Exception if the value is an Err.
      * @return mixed
      * @psalm-return T
+     * @throws Exception if the value is an Err.
      */
     abstract public function unwrap();
 
     /**
      * Unwraps a result, yielding the content of an Ok.
      *
-     * @throws Exception the message if the value is an Err.
      * @param Exception $msg
      * @return mixed
      * @psalm-return T
+     * @throws Exception the message if the value is an Err.
      */
     abstract public function expect(Exception $msg);
 
     /**
      * Unwraps a result, yielding the content of an Err.
      *
-     * @throws ResultException if the value is an Ok.
      * @return mixed
      * @psalm-return E
+     * @throws ResultException if the value is an Ok.
      */
     abstract public function unwrapErr();
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -58,9 +58,12 @@ abstract class Result
     /**
      * Maps a Result by applying a function to a contained Ok value, leaving an Err value untouched.
      *
+     * @template U
+     *
      * @param Closure $mapper
-     * @psalm-param Closure(T):T $mapper
+     * @psalm-param Closure(T=,mixed...):U $mapper
      * @return Result
+     * @psalm-return Result<U,E>
      */
     abstract public function map(Closure $mapper): Result;
 
@@ -68,8 +71,9 @@ abstract class Result
      * Maps a Result by applying a function to a contained Err value, leaving an Ok value untouched.
      *
      * @param Closure $mapper
-     * @psalm-param Closure(E):E $mapper
+     * @psalm-param Closure(E=):E $mapper
      * @return Result
+     * @psalm-return Result<T,E>
      */
     abstract public function mapErr(Closure $mapper): Result;
 
@@ -85,51 +89,72 @@ abstract class Result
     /**
      * Returns res if the result is Ok, otherwise returns the Err value of self.
      *
+     * @template U
+     *
      * @param Result $res
+     * @psalm-param Result<U,E> $res
      * @return Result
+     * @psalm-return Result<U,E>
      */
     abstract public function and(Result $res): Result;
 
     /**
      * Calls op if the result is Ok, otherwise returns the Err value of self.
      *
+     * @template U
+     *
      * @param Closure $op
+     * @psalm-param Closure(T=,mixed...):Result<U,E> $op
      * @return Result
+     * @psalm-return Result<U,E>
      */
     abstract public function andThen(Closure $op): Result;
 
     /**
      * Returns res if the result is Err, otherwise returns the Ok value of self.
      *
+     * @template F
+     *
      * @param Result $res
+     * @psalm-param Result<T,F> $res
      * @return Result
+     * @psalm-return Result<T,F>
      */
     abstract public function or(Result $res): Result;
 
     /**
      * Calls op if the result is Err, otherwise returns the Ok value of self.
      *
+     * @template F
+     *
      * @param Closure $op
+     * @psalm-param Closure(E=):F $op
      * @return Result
+     * @psalm-return Result<T,F>
      */
     abstract public function orElse(Closure $op): Result;
 
     /**
      * Unwraps a result, yielding the content of an Ok. Else, it returns optb.
      *
+     * @template U
+     *
      * @param mixed $optb
+     * @psalm-param U $optb
      * @return mixed
-     * @psalm-return T|mixed
+     * @psalm-return T|U
      */
     abstract public function unwrapOr($optb);
 
     /**
      * Unwraps a result, yielding the content of an Ok. If the value is an Err then it calls op with its value.
      *
+     * @template U
+     *
      * @param Closure $op
-     * @psalm-param Closure(E) $op
+     * @psalm-param Closure(E=):U $op
      * @return mixed
-     * @psalm-return T|mixed
+     * @psalm-return T|U
      */
     abstract public function unwrapOrElse(Closure $op);
 
@@ -145,7 +170,10 @@ abstract class Result
     /**
      * Unwraps a result, yielding the content of an Ok.
      *
+     * @template X as Exception
+     *
      * @param Exception $msg
+     * @psalm-param X&Exception $msg
      * @return mixed
      * @psalm-return T
      * @throws Exception the message if the value is an Err.
@@ -164,16 +192,17 @@ abstract class Result
     /**
      * Applies values inside the given Results to the function in this Result.
      *
-     * @param Result[] ...$inArgs Results to apply the function to.
+     * @param Result ...$inArgs Results to apply the function to.
      * @psalm-param Result ...$inArgs
      * @return Result
+     * @psalm-return Result
      */
     abstract public function apply(Result ...$inArgs): Result;
 
     /**
      * The attached pass-through args will be unpacked into extra args into chained closures
      *
-     * @param array ...$args
+     * @param mixed ...$args
      * @return Result
      */
     abstract public function with(...$args): Result;

--- a/src/Result.php
+++ b/src/Result.php
@@ -71,7 +71,7 @@ abstract class Result
      * Maps a Result by applying a function to a contained Err value, leaving an Ok value untouched.
      *
      * @param Closure $mapper
-     * @psalm-param Closure(E=):E $mapper
+     * @psalm-param Closure(E=,mixed...):E $mapper
      * @return Result
      * @psalm-return Result<T,E>
      */
@@ -128,7 +128,7 @@ abstract class Result
      * @template F
      *
      * @param Closure $op
-     * @psalm-param Closure(E=):F $op
+     * @psalm-param Closure(E=,mixed...):F $op
      * @return Result
      * @psalm-return Result<T,F>
      */
@@ -152,7 +152,7 @@ abstract class Result
      * @template U
      *
      * @param Closure $op
-     * @psalm-param Closure(E=):U $op
+     * @psalm-param Closure(E=,mixed...):U $op
      * @return mixed
      * @psalm-return T|U
      */

--- a/src/Result.php
+++ b/src/Result.php
@@ -71,9 +71,9 @@ abstract class Result
      * Maps a Result by applying a function to a contained Err value, leaving an Ok value untouched.
      *
      * @param Closure $mapper
-     * @psalm-param Closure(E=,mixed...):E $mapper
+     * @psalm-param Closure(E=,mixed...):F $mapper
      * @return Result
-     * @psalm-return Result<T,E>
+     * @psalm-return Result<T,F>
      */
     abstract public function mapErr(Closure $mapper): Result;
 
@@ -128,7 +128,7 @@ abstract class Result
      * @template F
      *
      * @param Closure $op
-     * @psalm-param Closure(E=,mixed...):F $op
+     * @psalm-param Closure(E=,mixed...):Result<T,F> $op
      * @return Result
      * @psalm-return Result<T,F>
      */
@@ -137,24 +137,20 @@ abstract class Result
     /**
      * Unwraps a result, yielding the content of an Ok. Else, it returns optb.
      *
-     * @template U
-     *
      * @param mixed $optb
-     * @psalm-param U $optb
+     * @psalm-param T $optb
      * @return mixed
-     * @psalm-return T|U
+     * @psalm-return T
      */
     abstract public function unwrapOr($optb);
 
     /**
      * Unwraps a result, yielding the content of an Ok. If the value is an Err then it calls op with its value.
      *
-     * @template U
-     *
      * @param Closure $op
-     * @psalm-param Closure(E=,mixed...):U $op
+     * @psalm-param Closure(E=,mixed...):T $op
      * @return mixed
-     * @psalm-return T|U
+     * @psalm-return T
      */
     abstract public function unwrapOrElse(Closure $op);
 
@@ -193,9 +189,7 @@ abstract class Result
      * Applies values inside the given Results to the function in this Result.
      *
      * @param Result ...$inArgs Results to apply the function to.
-     * @psalm-param Result ...$inArgs
      * @return Result
-     * @psalm-return Result
      */
     abstract public function apply(Result ...$inArgs): Result;
 
@@ -204,6 +198,7 @@ abstract class Result
      *
      * @param mixed ...$args
      * @return Result
+     * @psalm-return Result<T,E>
      */
     abstract public function with(...$args): Result;
 }

--- a/src/Result/Err.php
+++ b/src/Result/Err.php
@@ -100,7 +100,7 @@ class Err extends Result
      * The iterator yields one value if the result is Ok, otherwise none.
      *
      * @return array
-     * @psalm-return array<int, mixed>
+     * @psalm-return array<int, T>
      */
     public function iter(): array
     {

--- a/src/Result/Err.php
+++ b/src/Result/Err.php
@@ -25,7 +25,7 @@ use Prewk\Result;
  * @template E
  * The Err value
  *
- * @inherits Result<T, E>
+ * @template-extends Result<T, E>
  */
 class Err extends Result
 {
@@ -54,9 +54,7 @@ class Err extends Result
     }
 
     /**
-     * Returns true if the result is Ok.
-     *
-     * @return bool
+     * @inheritDoc
      */
     public function isOk(): bool
     {
@@ -64,9 +62,7 @@ class Err extends Result
     }
 
     /**
-     * Returns true if the result is Err.
-     *
-     * @return bool
+     * @inheritDoc
      */
     public function isErr(): bool
     {
@@ -74,10 +70,9 @@ class Err extends Result
     }
 
     /**
-     * Maps a Result by applying a function to a contained Ok value, leaving an Err value untouched.
+     * @inheritDoc
      *
-     * @param Closure $mapper
-     * @return Result
+     * @return $this
      */
     public function map(Closure $mapper): Result
     {
@@ -85,10 +80,7 @@ class Err extends Result
     }
 
     /**
-     * Maps a Result by applying a function to a contained Err value, leaving an Ok value untouched.
-     *
-     * @param Closure $mapper
-     * @return Result
+     * @inheritDoc
      */
     public function mapErr(Closure $mapper): Result
     {
@@ -96,11 +88,7 @@ class Err extends Result
     }
 
     /**
-     * Returns an iterator over the possibly contained value.
-     * The iterator yields one value if the result is Ok, otherwise none.
-     *
-     * @return array
-     * @psalm-return array<int, T>
+     * @inheritDoc
      */
     public function iter(): array
     {
@@ -108,10 +96,9 @@ class Err extends Result
     }
 
     /**
-     * Returns res if the result is Ok, otherwise returns the Err value of self.
+     * @inheritDoc
      *
-     * @param Result $res
-     * @return Result
+     * @return $this
      */
     public function and(Result $res): Result
     {
@@ -119,10 +106,7 @@ class Err extends Result
     }
 
     /**
-     * Calls op if the result is Ok, otherwise returns the Err value of self.
-     *
-     * @param Closure $op
-     * @return Result
+     * @inheritDoc
      */
     public function andThen(Closure $op): Result
     {
@@ -130,10 +114,7 @@ class Err extends Result
     }
 
     /**
-     * Returns res if the result is Err, otherwise returns the Ok value of self.
-     *
-     * @param Result $res
-     * @return Result
+     * @inheritDoc
      */
     public function or(Result $res): Result
     {
@@ -141,11 +122,12 @@ class Err extends Result
     }
 
     /**
-     * Calls op if the result is Err, otherwise returns the Ok value of self.
+     * @inheritDoc
      *
-     * @param Closure $op T -> Result<T>
-     * @return Result
      * @throws ResultException on invalid op return type
+     * @psalm-assert !Closure(T=):Result $op
+     *
+     * @psalm-suppress DocblockTypeContradiction We cannot be completely sure, that in argument valid callable
      */
     public function orElse(Closure $op): Result
     {
@@ -159,11 +141,9 @@ class Err extends Result
     }
 
     /**
-     * Unwraps a result, yielding the content of an Ok. Else, it returns optb.
+     * @inheritDoc
      *
-     * @param $optb
-     * @return mixed
-     * @psalm-return T|mixed
+     * @psalm-return U
      */
     public function unwrapOr($optb)
     {
@@ -171,11 +151,9 @@ class Err extends Result
     }
 
     /**
-     * Unwraps a result, yielding the content of an Ok. If the value is an Err then it calls op with its value.
+     * @inheritDoc
      *
-     * @param Closure $op
-     * @return mixed
-     * @psalm-return T|mixed
+     * @psalm-return U
      */
     public function unwrapOrElse(Closure $op)
     {
@@ -183,12 +161,9 @@ class Err extends Result
     }
 
     /**
-     * Unwraps a result, yielding the content of an Ok.
+     * @inheritDoc
      *
-     * @throws Exception|ResultException If the value is an Err, unwrapping will throw it if it's an exception
-     *                                   or ResultException if it is not.
-     * @return void
-     * @psalm-return no-return
+     * @psalm-return never-return
      */
     public function unwrap()
     {
@@ -200,12 +175,9 @@ class Err extends Result
     }
 
     /**
-     * Unwraps a result, yielding the content of an Ok.
+     * @inheritDoc
      *
-     * @param Exception $msg
-     * @return mixed
-     * @psalm-return T
-     * @throws Exception the message if the value is an Err.
+     * @psalm-return never-return
      */
     public function expect(Exception $msg)
     {
@@ -213,11 +185,7 @@ class Err extends Result
     }
 
     /**
-     * Unwraps a result, yielding the content of an Err.
-     *
-     * @throws if the value is an Ok.
-     * @return mixed
-     * @psalm-return E
+     * @inheritDoc
      */
     public function unwrapErr()
     {
@@ -225,11 +193,9 @@ class Err extends Result
     }
 
     /**
-     * Applies values inside the given Results to the function in this Result.
+     * @inheritDoc
      *
-     * @param Result[] ...$inArgs Results to apply the function to.
-     * @psalm-param Result ...$inArgs
-     * @return Result
+     * @return $this
      */
     public function apply(Result ...$inArgs): Result
     {
@@ -237,10 +203,7 @@ class Err extends Result
     }
 
     /**
-     * Converts from Result<T, E> to Option<T>, and discarding the error, if any
-     *
-     * @return Option
-     * @psalm-return Option<mixed>
+     * @inheritDoc
      */
     public function ok(): Option
     {
@@ -248,10 +211,7 @@ class Err extends Result
     }
 
     /**
-     * Converts from Result<T, E> to Option<E>, and discarding the value, if any
-     *
-     * @return Option
-     * @psalm-return Option<mixed>
+     * @inheritDoc
      */
     public function err(): Option
     {
@@ -259,10 +219,9 @@ class Err extends Result
     }
 
     /**
-     * The attached pass-through args will be unpacked into extra args into chained closures
+     * @inheritDoc
      *
-     * @param array ...$args
-     * @return Result
+     * @return $this
      */
     public function with(...$args): Result
     {

--- a/src/Result/Err.php
+++ b/src/Result/Err.php
@@ -143,6 +143,8 @@ class Err extends Result
     /**
      * @inheritDoc
      *
+     * @template U
+     *
      * @psalm-return U
      */
     public function unwrapOr($optb)
@@ -152,6 +154,8 @@ class Err extends Result
 
     /**
      * @inheritDoc
+     *
+     * @template U
      *
      * @psalm-return U
      */

--- a/src/Result/Err.php
+++ b/src/Result/Err.php
@@ -54,7 +54,9 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Returns true if the result is Ok.
+     *
+     * @return bool
      */
     public function isOk(): bool
     {
@@ -62,7 +64,9 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Returns true if the result is Err.
+     *
+     * @return bool
      */
     public function isErr(): bool
     {
@@ -70,9 +74,14 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Maps a Result by applying a function to a contained Ok value, leaving an Err value untouched.
      *
-     * @return $this
+     * @template U
+     *
+     * @param Closure $mapper
+     * @psalm-param Closure(T=,mixed...):U $mapper
+     * @return Result
+     * @psalm-return Result<U,E>
      */
     public function map(Closure $mapper): Result
     {
@@ -80,7 +89,14 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Maps a Result by applying a function to a contained Err value, leaving an Ok value untouched.
+     *
+     * @template F
+     *
+     * @param Closure $mapper
+     * @psalm-param Closure(E=,mixed...):F $mapper
+     * @return Result
+     * @psalm-return Result<T,F>
      */
     public function mapErr(Closure $mapper): Result
     {
@@ -88,7 +104,11 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Returns an iterator over the possibly contained value.
+     * The iterator yields one value if the result is Ok, otherwise none.
+     *
+     * @return array
+     * @psalm-return array<int, T>
      */
     public function iter(): array
     {
@@ -96,9 +116,14 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Returns res if the result is Ok, otherwise returns the Err value of self.
      *
-     * @return $this
+     * @template U
+     *
+     * @param Result $res
+     * @psalm-param Result<U,E> $res
+     * @return Result
+     * @psalm-return Result<U,E>
      */
     public function and(Result $res): Result
     {
@@ -106,7 +131,14 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Calls op if the result is Ok, otherwise returns the Err value of self.
+     *
+     * @template U
+     *
+     * @param Closure $op
+     * @psalm-param Closure(T=,mixed...):Result<U,E> $op
+     * @return Result
+     * @psalm-return Result<U,E>
      */
     public function andThen(Closure $op): Result
     {
@@ -114,7 +146,14 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Returns res if the result is Err, otherwise returns the Ok value of self.
+     *
+     * @template F
+     *
+     * @param Result $res
+     * @psalm-param Result<T,F> $res
+     * @return Result
+     * @psalm-return Result<T,F>
      */
     public function or(Result $res): Result
     {
@@ -122,7 +161,14 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Calls op if the result is Err, otherwise returns the Ok value of self.
+     *
+     * @template F
+     *
+     * @param Closure $op
+     * @psalm-param Closure(E=,mixed...):Result<T,F> $op
+     * @return Result
+     * @psalm-return Result<T,F>
      *
      * @throws ResultException on invalid op return type
      * @psalm-assert !Closure(T=):Result $op
@@ -141,11 +187,12 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Unwraps a result, yielding the content of an Ok. Else, it returns optb.
      *
-     * @template U
-     *
-     * @psalm-return U
+     * @param mixed $optb
+     * @psalm-param T $optb
+     * @return mixed
+     * @psalm-return T
      */
     public function unwrapOr($optb)
     {
@@ -153,11 +200,12 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Unwraps a result, yielding the content of an Ok. If the value is an Err then it calls op with its value.
      *
-     * @template U
-     *
-     * @psalm-return U
+     * @param Closure $op
+     * @psalm-param Closure(E=,mixed...):T $op
+     * @return mixed
+     * @psalm-return T
      */
     public function unwrapOrElse(Closure $op)
     {
@@ -165,9 +213,11 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Unwraps a result, yielding the content of an Ok.
      *
+     * @return void
      * @psalm-return never-return
+     * @throws Exception if the value is an Err.
      */
     public function unwrap()
     {
@@ -179,9 +229,15 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Unwraps a result, yielding the content of an Ok.
      *
+     * @template X as Exception
+     *
+     * @param Exception $msg
+     * @psalm-param X&Exception $msg
+     * @return void
      * @psalm-return never-return
+     * @throws Exception the message if the value is an Err.
      */
     public function expect(Exception $msg)
     {
@@ -189,7 +245,10 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Unwraps a result, yielding the content of an Err.
+     *
+     * @return mixed
+     * @psalm-return E
      */
     public function unwrapErr()
     {
@@ -197,9 +256,11 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Applies values inside the given Results to the function in this Result.
      *
-     * @return $this
+     * @param Result ...$inArgs Results to apply the function to.
+     * @return Result
+     * @psalm-return Result<mixed,E>
      */
     public function apply(Result ...$inArgs): Result
     {
@@ -207,7 +268,10 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Converts from Result<T, E> to Option<T>, and discarding the error, if any
+     *
+     * @return Option
+     * @psalm-return Option<T>
      */
     public function ok(): Option
     {
@@ -215,7 +279,10 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * Converts from Result<T, E> to Option<E>, and discarding the value, if any
+     *
+     * @return Option
+     * @psalm-return Option<E>
      */
     public function err(): Option
     {
@@ -223,9 +290,11 @@ class Err extends Result
     }
 
     /**
-     * @inheritDoc
+     * The attached pass-through args will be unpacked into extra args into chained closures
      *
-     * @return $this
+     * @param mixed ...$args
+     * @return Result
+     * @psalm-return Result<T,E>
      */
     public function with(...$args): Result
     {

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -188,7 +188,7 @@ class Ok extends Result
      *
      * @throws ResultException
      *
-     * @psalm-return Result<array,E>
+     * @psalm-return Result<mixed,E>
      *
      * @psalm-suppress MissingClosureReturnType
      */

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -214,10 +214,7 @@ class Ok extends Result
     }
 
     /**
-     * Converts from Result<T, E> to Option<T>, and discarding the error, if any
-     *
-     * @return Option
-     * @psalm-return Option<T>
+     * @inheritDoc
      */
     public function ok(): Option
     {
@@ -225,10 +222,7 @@ class Ok extends Result
     }
 
     /**
-     * Converts from Result<T, E> to Option<E>, and discarding the value, if any
-     *
-     * @return Option
-     * @psalm-return Option<mixed>
+     * @inheritDoc
      */
     public function err(): Option
     {
@@ -236,9 +230,8 @@ class Ok extends Result
     }
 
     /**
-     * The attached pass-through args will be unpacked into extra args into chained closures
+     * @inheritDoc
      *
-     * @param mixed ...$args
      * @return $this
      */
     public function with(...$args): Result

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -54,7 +54,9 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Returns true if the result is Ok.
+     *
+     * @return true
      */
     public function isOk(): bool
     {
@@ -62,7 +64,9 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Returns true if the result is Err.
+     *
+     * @return false
      */
     public function isErr(): bool
     {
@@ -70,7 +74,14 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Maps a Result by applying a function to a contained Ok value, leaving an Err value untouched.
+     *
+     * @template U
+     *
+     * @param Closure $mapper
+     * @psalm-param Closure(T=,mixed...):U $mapper
+     * @return Result
+     * @psalm-return Result<U,E>
      */
     public function map(Closure $mapper): Result
     {
@@ -78,7 +89,14 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Maps a Result by applying a function to a contained Err value, leaving an Ok value untouched.
+     *
+     * @template F
+     *
+     * @param Closure $mapper
+     * @psalm-param Closure(E=,mixed...):F $mapper
+     * @return Result
+     * @psalm-return Result<T,F>
      */
     public function mapErr(Closure $mapper): Result
     {
@@ -86,7 +104,11 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Returns an iterator over the possibly contained value.
+     * The iterator yields one value if the result is Ok, otherwise none.
+     *
+     * @return array
+     * @psalm-return array<int, T>
      */
     public function iter(): array
     {
@@ -94,7 +116,14 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Returns res if the result is Ok, otherwise returns the Err value of self.
+     *
+     * @template U
+     *
+     * @param Result $res
+     * @psalm-param Result<U,E> $res
+     * @return Result
+     * @psalm-return Result<U,E>
      */
     public function and(Result $res): Result
     {
@@ -102,7 +131,14 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Calls op if the result is Ok, otherwise returns the Err value of self.
+     *
+     * @template U
+     *
+     * @param Closure $op
+     * @psalm-param Closure(T=,mixed...):Result<U,E> $op
+     * @return Result
+     * @psalm-return Result<U,E>
      *
      * @throws ResultException on invalid op return type
      * @psalm-assert !Closure(T=):Result $op
@@ -121,7 +157,14 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Returns res if the result is Err, otherwise returns the Ok value of self.
+     *
+     * @template F
+     *
+     * @param Result $res
+     * @psalm-param Result<T,F> $res
+     * @return Result
+     * @psalm-return Result<T,F>
      */
     public function or(Result $res): Result
     {
@@ -129,7 +172,14 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Calls op if the result is Err, otherwise returns the Ok value of self.
+     *
+     * @template F
+     *
+     * @param Closure $op
+     * @psalm-param Closure(E=,mixed...):Result<T,F> $op
+     * @return Result
+     * @psalm-return Result<T,F>
      */
     public function orElse(Closure $op): Result
     {
@@ -137,8 +187,12 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
      *
+     * Unwraps a result, yielding the content of an Ok. Else, it returns optb.
+     *
+     * @param mixed $optb
+     * @psalm-param T $optb
+     * @return mixed
      * @psalm-return T
      */
     public function unwrapOr($optb)
@@ -147,8 +201,11 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Unwraps a result, yielding the content of an Ok. If the value is an Err then it calls op with its value.
      *
+     * @param Closure $op
+     * @psalm-param Closure(E=,mixed...):T $op
+     * @return mixed
      * @psalm-return T
      */
     public function unwrapOrElse(Closure $op)
@@ -157,7 +214,10 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Unwraps a result, yielding the content of an Ok.
+     *
+     * @return mixed
+     * @psalm-return T
      */
     public function unwrap()
     {
@@ -165,7 +225,11 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Unwraps a result, yielding the content of an Ok.
+     *
+     * @param Exception $msg
+     * @return mixed
+     * @psalm-return T
      */
     public function expect(Exception $msg)
     {
@@ -173,8 +237,9 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Unwraps a result, yielding the content of an Err.
      *
+     * @return void
      * @psalm-return never-return
      * @throws ResultException if the value is an Ok.
      */
@@ -184,11 +249,13 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Applies values inside the given Results to the function in this Result.
+     *
+     * @param Result ...$inArgs Results to apply the function to.
+     * @return Result
+     * @psalm-return Result<mixed,E>
      *
      * @throws ResultException
-     *
-     * @psalm-return Result<mixed,E>
      *
      * @psalm-suppress MissingClosureReturnType
      */
@@ -212,7 +279,10 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Converts from Result<T, E> to Option<T>, and discarding the error, if any
+     *
+     * @return Option
+     * @psalm-return Option<T>
      */
     public function ok(): Option
     {
@@ -220,7 +290,10 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * Converts from Result<T, E> to Option<E>, and discarding the value, if any
+     *
+     * @return Option
+     * @psalm-return Option<E>
      */
     public function err(): Option
     {
@@ -228,9 +301,11 @@ class Ok extends Result
     }
 
     /**
-     * @inheritDoc
+     * The attached pass-through args will be unpacked into extra args into chained closures
      *
-     * @return $this
+     * @param mixed ...$args
+     * @return Result
+     * @psalm-return Result<T,E>
      */
     public function with(...$args): Result
     {

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -190,8 +190,6 @@ class Ok extends Result
      *
      * @psalm-return Result<array,E>
      *
-//     * @psalm-assert T!=callable $this->value
-//     * @psalm-assert T!=callable(T=,...mixed=):Result<array,E> $this->value
      * @psalm-suppress MissingClosureReturnType
      */
     public function apply(Result ...$inArgs): Result

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -100,7 +100,7 @@ class Ok extends Result
      * The iterator yields one value if the result is Ok, otherwise none.
      *
      * @return array
-     * @psalm-return array<int, mixed>
+     * @psalm-return array<int, T>
      */
     public function iter(): array
     {
@@ -185,7 +185,6 @@ class Ok extends Result
     /**
      * Unwraps a result, yielding the content of an Ok.
      *
-     * @throws if the value is an Err.
      * @return mixed
      * @psalm-return T
      */
@@ -197,10 +196,10 @@ class Ok extends Result
     /**
      * Unwraps a result, yielding the content of an Ok.
      *
-     * @throws Exception (the message) if the value is an Err.
      * @param Exception $msg
      * @return mixed
      * @psalm-return T
+     * @throws Exception (the message) if the value is an Err.
      */
     public function expect(Exception $msg)
     {
@@ -210,9 +209,9 @@ class Ok extends Result
     /**
      * Unwraps a result, yielding the content of an Err.
      *
-     * @throws ResultException if the value is an Ok.
      * @return mixed
      * @psalm-return E
+     * @throws ResultException if the value is an Ok.
      */
     public function unwrapErr()
     {
@@ -252,7 +251,7 @@ class Ok extends Result
      * Converts from Result<T, E> to Option<T>, and discarding the error, if any
      *
      * @return Option
-     * @psalm-return Option<mixed>
+     * @psalm-return Option<T>
      */
     public function ok(): Option
     {


### PR DESCRIPTION
What needed to be resolved:
1) write some examples, from which psalm now can prevent developers (maybe I will adapt examples from Rust docs) and ensure, that all phpdoc corrected;
2) choose the way for working with phpdoc copypaste between abstract and concrete - copy and use only needed, use '@inheritdoc', use '@inheritdoc' and specify more corrected types (`never-returns`, when only thrown exception, for example);
3) I cannot cover `callable T` + `with()` + `$this->pass` features by psalm. I think it will be preserved as it now. Possibly it can be covered by custom psalm plugin;
4) Some Rust docs examples make me confusing, when types are converted on some `map.../...else` methods - example `unwrapOr()` (unwrap_or Rust) method. - it declare `optb` as `T` type (same as original), but we don't check it in php implementation; or `map()` - docs declred, that result always "converted" to <U,E> types; maybe it's too new for me, I never worked with Rust. 