### PR TITLE
Support callables

### DIFF
--- a/spec/Result/ErrSpec.php
+++ b/spec/Result/ErrSpec.php
@@ -32,7 +32,16 @@ class ErrSpec extends ObjectBehavior
     function it_doesnt_map()
     {
         $this->beConstructedWith("error");
-        $this->map(function () {})->shouldHaveType(Err::class);
+        $this->map(function () {
+        })->shouldHaveType(Err::class);
+
+        $instance = new class
+        {
+            public function f($value)
+            {
+            }
+        };
+        $this->map([$instance, 'f'])->shouldHaveType(Err::class);
     }
 
     function it_mapErrs()
@@ -44,6 +53,18 @@ class ErrSpec extends ObjectBehavior
 
         $result->shouldHaveType(Err::class);
         $result->unwrapErr()->shouldBe("foobar");
+
+        $instance = new class
+        {
+            public function f($err)
+            {
+                return $err . "baz";
+            }
+        };
+
+        $result = $this->mapErr([$instance, 'f']);
+        $result->shouldHaveType(Err::class);
+        $result->unwrapErr()->shouldBe("foobaz");
     }
 
     function it_returns_an_iterator()
@@ -61,7 +82,16 @@ class ErrSpec extends ObjectBehavior
     function it_shouldnt_andThen()
     {
         $this->beConstructedWith("error");
-        $this->andThen(function () {})->shouldHaveType(Err::class);
+        $this->andThen(function () {
+        })->shouldHaveType(Err::class);
+
+        $instance = new class
+        {
+            public function f($err)
+            {
+            }
+        };
+        $this->andThen([$instance, 'f'])->shouldHaveType(Err::class);
     }
 
     function it_should_or()
@@ -81,6 +111,15 @@ class ErrSpec extends ObjectBehavior
             $otherValue = new Err($err . "rorre");
             return $otherValue;
         })->shouldBe($otherValue);
+
+        $instance = new class
+        {
+            public function f($err)
+            {
+                return new Err($err . "baz");
+            }
+        };
+        $this->orElse([$instance, 'f'])->unwrapErr()->shouldBe("errorbaz");
     }
 
     function it_unwrapOrs()
@@ -95,6 +134,15 @@ class ErrSpec extends ObjectBehavior
         $this->unwrapOrElse(function ($err) {
             return "non-" . $err;
         })->shouldBe("non-error");
+
+        $instance = new class
+        {
+            public function f($err)
+            {
+                return "non-" . $err;
+            }
+        };
+        $this->unwrapOrElse([$instance, 'f'])->shouldBe("non-error");
     }
 
     function it_throws_ResultException_on_unwrapping_non_exceptions()
@@ -155,6 +203,18 @@ class ErrSpec extends ObjectBehavior
 
         $result->shouldHaveType(Err::class);
         $result->unwrapErr()->shouldBe("foobarbaz");
+
+        $instance = new class
+        {
+            public function f($foo, $bar, $baz)
+            {
+                return $foo . $baz . $bar;
+            }
+        };
+
+        $result = $this->mapErr([$instance, 'f']);
+        $result->shouldHaveType(Err::class);
+        $result->unwrapErr()->shouldBe("foobazbar");
     }
 
     function it_orElses_with_pass_args()
@@ -165,6 +225,16 @@ class ErrSpec extends ObjectBehavior
         });
 
         $result->unwrapErr()->shouldBe("foobarbaz");
+
+        $instance = new class
+        {
+            public function f($foo, $bar, $baz)
+            {
+                return new Err($foo . $baz . $bar);
+            }
+        };
+        $result = $this->orElse([$instance, 'f']);
+        $result->unwrapErr()->shouldBe("foobazbar");
     }
 
     function its_with_method_adds_args()

--- a/spec/Result/OkSpec.php
+++ b/spec/Result/OkSpec.php
@@ -52,7 +52,7 @@ class OkSpec extends ObjectBehavior
         $result->unwrap()->shouldBe("foobarbar");
     }
 
-    function it_doesnt_errMap()
+    function it_doesnt_mapErr()
     {
         $this->beConstructedWith("foo");
         $result = $this->mapErr(function ($value) {

--- a/spec/Result/OkSpec.php
+++ b/spec/Result/OkSpec.php
@@ -37,6 +37,19 @@ class OkSpec extends ObjectBehavior
 
         $result->shouldHaveType(Ok::class);
         $result->unwrap()->shouldBe("foobar");
+
+        $instance = new class
+        {
+            public function f($value)
+            {
+                return $value . "bar";
+            }
+        };
+
+        $result = $result->map([$instance, 'f']);
+
+        $result->shouldHaveType(Ok::class);
+        $result->unwrap()->shouldBe("foobarbar");
     }
 
     function it_doesnt_errMap()
@@ -44,6 +57,18 @@ class OkSpec extends ObjectBehavior
         $this->beConstructedWith("foo");
         $result = $this->mapErr(function ($value) {
         });
+
+        $result->shouldHaveType(Ok::class);
+        $result->unwrap()->shouldBe("foo");
+
+        $instance = new class
+        {
+            public function f($value)
+            {
+            }
+        };
+
+        $result = $result->mapErr([$instance, 'f']);
 
         $result->shouldHaveType(Ok::class);
         $result->unwrap()->shouldBe("foo");
@@ -70,6 +95,15 @@ class OkSpec extends ObjectBehavior
             $otherResult = new Ok($value . "bar");
             return $otherResult;
         })->shouldBe($otherResult);
+
+        $instance = new class
+        {
+            public function f($value)
+            {
+                return new Ok("andThen");
+            }
+        };
+        $this->andThen([$instance, 'f'])->unwrap()->shouldBe("andThen");
     }
 
     function it_ors()
@@ -83,6 +117,14 @@ class OkSpec extends ObjectBehavior
         $this->beConstructedWith("foo");
         $this->orElse(function () {
         })->shouldHaveType(Ok::class);
+
+        $instance = new class
+        {
+            public function f($value)
+            {
+            }
+        };
+        $this->orElse([$instance, 'f'])->shouldHaveType(Ok::class);
     }
 
     function it_unwrapOrs_with_its_value()
@@ -96,6 +138,14 @@ class OkSpec extends ObjectBehavior
         $this->beConstructedWith("value");
         $this->unwrapOrElse(function () {
         })->shouldBe("value");
+
+        $instance = new class
+        {
+            public function f($value)
+            {
+            }
+        };
+        $this->unwrapOrElse([$instance, 'f'])->shouldBe("value");
     }
 
     function it_unwraps_with_its_value()
@@ -173,6 +223,18 @@ class OkSpec extends ObjectBehavior
 
         $result->shouldHaveType(Ok::class);
         $result->unwrap()->shouldBe("foobarbaz");
+
+        $instance = new class
+        {
+            public function f($foo, $bar, $baz)
+            {
+                return $foo . $baz . $bar;
+            }
+        };
+
+        $result = $this->map([$instance, 'f']);
+        $result->shouldHaveType(Ok::class);
+        $result->unwrap()->shouldBe("foobazbar");
     }
 
     function it_andThens_with_pass_args()
@@ -183,6 +245,17 @@ class OkSpec extends ObjectBehavior
         });
 
         $result->unwrap()->shouldBe("foobarbaz");
+
+        $instance = new class
+        {
+            public function f($foo, $bar, $baz)
+            {
+                return new Ok($foo . $baz . $bar);
+            }
+        };
+
+        $result = $this->andThen([$instance, 'f']);
+        $result->unwrap()->shouldBe("foobazbar");
     }
 
     function its_with_method_adds_args()
@@ -195,5 +268,16 @@ class OkSpec extends ObjectBehavior
         });
 
         $result->unwrap()->shouldBe("foobarbaz");
+
+        $instance = new class
+        {
+            public function f($foo, $bar, $baz)
+            {
+                return new Ok($baz . $foo . $bar);
+            }
+        };
+
+        $result = $this->andThen([$instance, 'f']);
+        $result->unwrap()->shouldBe("bazfoobar");
     }
 }

--- a/spec/Result/OkSpec.php
+++ b/spec/Result/OkSpec.php
@@ -268,16 +268,5 @@ class OkSpec extends ObjectBehavior
         });
 
         $result->unwrap()->shouldBe("foobarbaz");
-
-        $instance = new class
-        {
-            public function f($foo, $bar, $baz)
-            {
-                return new Ok($baz . $foo . $bar);
-            }
-        };
-
-        $result = $this->andThen([$instance, 'f']);
-        $result->unwrap()->shouldBe("bazfoobar");
     }
 }

--- a/src/Result.php
+++ b/src/Result.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Result
  *
@@ -10,7 +11,6 @@ declare(strict_types=1);
 
 namespace Prewk;
 
-use Closure;
 use Exception;
 use Prewk\Result\ResultException;
 
@@ -60,24 +60,24 @@ abstract class Result
      *
      * @template U
      *
-     * @param Closure $mapper
-     * @psalm-param Closure(T=,mixed...):U $mapper
+     * @param callable $mapper
+     * @psalm-param callable(T=,mixed...):U $mapper
      * @return Result
      * @psalm-return Result<U,E>
      */
-    abstract public function map(Closure $mapper): Result;
+    abstract public function map(callable $mapper): Result;
 
     /**
      * Maps a Result by applying a function to a contained Err value, leaving an Ok value untouched.
      *
      * @template F
      *
-     * @param Closure $mapper
-     * @psalm-param Closure(E=,mixed...):F $mapper
+     * @param callable $mapper
+     * @psalm-param callable(E=,mixed...):F $mapper
      * @return Result
      * @psalm-return Result<T,F>
      */
-    abstract public function mapErr(Closure $mapper): Result;
+    abstract public function mapErr(callable $mapper): Result;
 
     /**
      * Returns an iterator over the possibly contained value.
@@ -105,12 +105,12 @@ abstract class Result
      *
      * @template U
      *
-     * @param Closure $op
-     * @psalm-param Closure(T=,mixed...):Result<U,E> $op
+     * @param callable $op
+     * @psalm-param callable(T=,mixed...):Result<U,E> $op
      * @return Result
      * @psalm-return Result<U,E>
      */
-    abstract public function andThen(Closure $op): Result;
+    abstract public function andThen(callable $op): Result;
 
     /**
      * Returns res if the result is Err, otherwise returns the Ok value of self.
@@ -129,12 +129,12 @@ abstract class Result
      *
      * @template F
      *
-     * @param Closure $op
-     * @psalm-param Closure(E=,mixed...):Result<T,F> $op
+     * @param callable $op
+     * @psalm-param callable(E=,mixed...):Result<T,F> $op
      * @return Result
      * @psalm-return Result<T,F>
      */
-    abstract public function orElse(Closure $op): Result;
+    abstract public function orElse(callable $op): Result;
 
     /**
      * Unwraps a result, yielding the content of an Ok. Else, it returns optb.
@@ -149,12 +149,12 @@ abstract class Result
     /**
      * Unwraps a result, yielding the content of an Ok. If the value is an Err then it calls op with its value.
      *
-     * @param Closure $op
-     * @psalm-param Closure(E=,mixed...):T $op
+     * @param callable $op
+     * @psalm-param callable(E=,mixed...):T $op
      * @return mixed
      * @psalm-return T
      */
-    abstract public function unwrapOrElse(Closure $op);
+    abstract public function unwrapOrElse(callable $op);
 
     /**
      * Unwraps a result, yielding the content of an Ok.
@@ -197,7 +197,7 @@ abstract class Result
     abstract public function apply(Result ...$inArgs): Result;
 
     /**
-     * The attached pass-through args will be unpacked into extra args into chained closures
+     * The attached pass-through args will be unpacked into extra args into chained callables
      *
      * @param mixed ...$args
      * @return Result

--- a/src/Result/Err.php
+++ b/src/Result/Err.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Err
  *
@@ -10,7 +11,6 @@ declare(strict_types=1);
 
 namespace Prewk\Result;
 
-use Closure;
 use Exception;
 use Prewk\Option;
 use Prewk\Option\{Some, None};
@@ -79,12 +79,12 @@ class Err extends Result
      *
      * @template U
      *
-     * @param Closure $mapper
-     * @psalm-param Closure(T=,mixed...):U $mapper
+     * @param callable $mapper
+     * @psalm-param callable(T=,mixed...):U $mapper
      * @return Result
      * @psalm-return Result<U,E>
      */
-    public function map(Closure $mapper): Result
+    public function map(callable $mapper): Result
     {
         return new self($this->err, ...$this->pass);
     }
@@ -94,12 +94,12 @@ class Err extends Result
      *
      * @template F
      *
-     * @param Closure $mapper
-     * @psalm-param Closure(E=,mixed...):F $mapper
+     * @param callable $mapper
+     * @psalm-param callable(E=,mixed...):F $mapper
      * @return Result
      * @psalm-return Result<T,F>
      */
-    public function mapErr(Closure $mapper): Result
+    public function mapErr(callable $mapper): Result
     {
         return new self($mapper($this->err, ...$this->pass));
     }
@@ -136,12 +136,12 @@ class Err extends Result
      *
      * @template U
      *
-     * @param Closure $op
-     * @psalm-param Closure(T=,mixed...):Result<U,E> $op
+     * @param callable $op
+     * @psalm-param callable(T=,mixed...):Result<U,E> $op
      * @return Result
      * @psalm-return Result<U,E>
      */
-    public function andThen(Closure $op): Result
+    public function andThen(callable $op): Result
     {
         return new self($this->err, ...$this->pass);
     }
@@ -166,14 +166,14 @@ class Err extends Result
      *
      * @template F
      *
-     * @param Closure $op
-     * @psalm-param Closure(E=,mixed...):Result<T,F> $op
+     * @param callable $op
+     * @psalm-param callable(E=,mixed...):Result<T,F> $op
      * @return Result
      * @psalm-return Result<T,F>
      *
-     * @psalm-assert !Closure(T=):Result $op
+     * @psalm-assert !callable(T=):Result $op
      */
-    public function orElse(Closure $op): Result
+    public function orElse(callable $op): Result
     {
         return $op($this->err, ...$this->pass);
     }
@@ -194,12 +194,12 @@ class Err extends Result
     /**
      * Unwraps a result, yielding the content of an Ok. If the value is an Err then it calls op with its value.
      *
-     * @param Closure $op
-     * @psalm-param Closure(E=,mixed...):T $op
+     * @param callable $op
+     * @psalm-param callable(E=,mixed...):T $op
      * @return mixed
      * @psalm-return T
      */
-    public function unwrapOrElse(Closure $op)
+    public function unwrapOrElse(callable $op)
     {
         return $op($this->err, ...$this->pass);
     }
@@ -282,7 +282,7 @@ class Err extends Result
     }
 
     /**
-     * The attached pass-through args will be unpacked into extra args into chained closures
+     * The attached pass-through args will be unpacked into extra args into chained callables
      *
      * @param mixed ...$args
      * @return Result

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Ok
  *
@@ -10,7 +11,6 @@ declare(strict_types=1);
 
 namespace Prewk\Result;
 
-use Closure;
 use Exception;
 use Prewk\Option;
 use Prewk\Option\{Some, None};
@@ -79,12 +79,12 @@ class Ok extends Result
      *
      * @template U
      *
-     * @param Closure $mapper
-     * @psalm-param Closure(T=,mixed...):U $mapper
+     * @param callable $mapper
+     * @psalm-param callable(T=,mixed...):U $mapper
      * @return Result
      * @psalm-return Result<U,E>
      */
-    public function map(Closure $mapper): Result
+    public function map(callable $mapper): Result
     {
         return new self($mapper($this->value, ...$this->pass));
     }
@@ -94,12 +94,12 @@ class Ok extends Result
      *
      * @template F
      *
-     * @param Closure $mapper
-     * @psalm-param Closure(E=,mixed...):F $mapper
+     * @param callable $mapper
+     * @psalm-param callable(E=,mixed...):F $mapper
      * @return Result
      * @psalm-return Result<T,F>
      */
-    public function mapErr(Closure $mapper): Result
+    public function mapErr(callable $mapper): Result
     {
         return new self($this->value, ...$this->pass);
     }
@@ -136,14 +136,14 @@ class Ok extends Result
      *
      * @template U
      *
-     * @param Closure $op
-     * @psalm-param Closure(T=,mixed...):Result<U,E> $op
+     * @param callable $op
+     * @psalm-param callable(T=,mixed...):Result<U,E> $op
      * @return Result
      * @psalm-return Result<U,E>
      *
-     * @psalm-assert !Closure(T=):Result $op
+     * @psalm-assert !callable(T=):Result $op
      */
-    public function andThen(Closure $op): Result
+    public function andThen(callable $op): Result
     {
         return $op($this->value, ...$this->pass);
     }
@@ -168,12 +168,12 @@ class Ok extends Result
      *
      * @template F
      *
-     * @param Closure $op
-     * @psalm-param Closure(E=,mixed...):Result<T,F> $op
+     * @param callable $op
+     * @psalm-param callable(E=,mixed...):Result<T,F> $op
      * @return Result
      * @psalm-return Result<T,F>
      */
-    public function orElse(Closure $op): Result
+    public function orElse(callable $op): Result
     {
         return new self($this->value, ...$this->pass);
     }
@@ -195,12 +195,12 @@ class Ok extends Result
     /**
      * Unwraps a result, yielding the content of an Ok. If the value is an Err then it calls op with its value.
      *
-     * @param Closure $op
-     * @psalm-param Closure(E=,mixed...):T $op
+     * @param callable $op
+     * @psalm-param callable(E=,mixed...):T $op
      * @return mixed
      * @psalm-return T
      */
-    public function unwrapOrElse(Closure $op)
+    public function unwrapOrElse(callable $op)
     {
         return $this->value;
     }
@@ -296,7 +296,7 @@ class Ok extends Result
     }
 
     /**
-     * The attached pass-through args will be unpacked into extra args into chained closures
+     * The attached pass-through args will be unpacked into extra args into chained callables
      *
      * @param mixed ...$args
      * @return Result


### PR DESCRIPTION
Fixes #2 

Is this what you had in mind?

Also, I am not sure if more should be added to the tests. If yes, any of the below two is preferable?

Separate methods like so

```php
    function it_maps_with_callable()
    {
        $instance = new class
        {
            public function f($value)
            {
                return $value . "bar";
            }
        };

        $this->beConstructedWith("foo");
        $result = $this->map([$instance, 'f']);

        $result->shouldHaveType(Ok::class);
        $result->unwrap()->shouldBe("foobar");
    }
```

Or performing the check in the same method like so

```php
    function it_maps()
    {
        $this->beConstructedWith("foo");
        $result = $this->map(function ($value) {
            return $value . "bar";
        });

        $result->shouldHaveType(Ok::class);
        $result->unwrap()->shouldBe("foobar");

        $instance = new class
        {
            public function f($value)
            {
                return $value . "bar";
            }
        };

        $result = $result->map([$instance, 'f']);

        $result->shouldHaveType(Ok::class);
        $result->unwrap()->shouldBe("foobarbar");
    }
```

I am not sure if it is something to test in the first place. It feels like it is.

@prewk 