### PR TITLE
feat!: `Result#iter(): array` -> `Result#iter(): iterable`

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -123,9 +123,9 @@ abstract class Result
      * Returns an iterator over the possibly contained value.
      * The iterator yields one value if the result is Ok, otherwise none.
      *
-     * @return list<T>
+     * @return iterable<int, T>
      */
-    abstract public function iter(): array;
+    abstract public function iter(): iterable;
 
     /**
      * Unwraps a result, yielding the content of an Ok.

--- a/src/Result/Err.php
+++ b/src/Result/Err.php
@@ -98,7 +98,7 @@ class Err extends Result
         return $this;
     }
 
-    public function iter(): array
+    public function iter(): iterable
     {
         return [];
     }

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -101,7 +101,7 @@ class Ok extends Result
         return $this;
     }
 
-    public function iter(): array
+    public function iter(): iterable
     {
         return [$this->value];
     }


### PR DESCRIPTION
makes more sense semantically